### PR TITLE
Fix DudenWord.grammar function

### DIFF
--- a/duden/__init__.py
+++ b/duden/__init__.py
@@ -1,5 +1,20 @@
 # -*- coding: utf-8 -*-
 
-__all__ = ['get', 'search']
+__all__ = [
+    'get', 'search',
+    'SINGULAR', 'PLURAL',
+    'PRASENS', 'PRATERITUM',
+    'INDIKATIV', 'IMPERATIV', 'KONJUKTIV_1', 'KONJUKTIV_2',
+    'PARTIZIP_1', 'PARTIZIP_2', 'INFINITIV_MIT_ZU',
+    'PERSON_1', 'PERSON_2', 'PERSON_3',
+    'NOMINATIV', 'GENITIV', 'DATIV', 'AKKUSATIV'
+]
 
 from .main import get, search
+
+from .main import (SINGULAR, PLURAL,
+                   PRASENS, PRATERITUM,
+                   INDIKATIV, IMPERATIV, KONJUKTIV_1, KONJUKTIV_2,
+                   PARTIZIP_1, PARTIZIP_2, INFINITIV_MIT_ZU,
+                   PERSON_1, PERSON_2, PERSON_3,
+                   NOMINATIV, GENITIV, DATIV, AKKUSATIV)

--- a/duden/main.py
+++ b/duden/main.py
@@ -48,6 +48,11 @@ PERSON_1 = 'Person I'
 PERSON_2 = 'Person II'
 PERSON_3 = 'Person III'
 
+NOMINATIV = 'Nominativ'
+GENITIV = 'Genitiv'
+DATIV = 'Dativ'
+AKKUSATIV = 'Akkusativ'
+
 
 class DudenWord():
 
@@ -304,7 +309,7 @@ class DudenWord():
                                 duden.INDIKATIV, duden.PERSON_3)
         ['er/sie/es läuft']
         """
-        tagged_strings = self.grammar_raw()
+        tagged_strings = self.grammar_raw
         target_tags = set(target_tags)
         return [string
                 for tags, string in tagged_strings


### PR DESCRIPTION
This now works
```python
> import duden
> w = duden.get('Hase')
> w.grammar()
['der Hase',
 'die Hasen',
 'des Hasen',
 'der Hasen',
 'dem Hasen',
 'den Hasen',
 'den Hasen',
 'die Hasen']

> w.grammar(duden.SINGULAR, duden.GENITIV)
['des Hasen']
```

Fixes #31