### PR TITLE
 Search for words instead of word url representations

### DIFF
--- a/duden/locale/de_DE.po
+++ b/duden/locale/de_DE.po
@@ -106,3 +106,9 @@ msgstr "Grammatik anzeigen"
 #: main.py:606
 msgid "Word '{}' not found"
 msgstr "Wort '{}' nicht gefunden"
+
+msgid "Found {} matching words. Use the -r/--result argument to specify which one to display."
+msgstr "{} passende Wörter genfunden. Benutze die Option -r/--result um das korrekte Ergebnis anzuzeigen."
+
+msgid "No result with number {}."
+msgstr "Kein Ergebnis Nummer {}."

--- a/duden/locale/duden.pot
+++ b/duden/locale/duden.pot
@@ -103,3 +103,8 @@ msgstr ""
 msgid "Word '{}' not found"
 msgstr ""
 
+msgid "Found {} matching words. Use the -r/--result argument to specify which one to display."
+msgstr ""
+
+msgid "No result with number {}."
+msgstr ""


### PR DESCRIPTION
Every word in duden database has a corresponding url - for example - for
the word müßig it's
https://www.duden.de/rechtschreibung/mueszig .

Previously, one had to type in the url form - that is - mueszig. With this
commit, users can use the word itself (with all accents) to search.

This commit adds two CLI arguments:
* -r/--result to choose the correct word in case of multiple matching
words
* --fuzzy to enable fuzzy searching (searches for parts of words, etc.)

Fixes #44 