### PR TITLE
Add executor to the top level directory

### DIFF
--- a/duden/locale/de_DE.po
+++ b/duden/locale/de_DE.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-05-20 14:02+0200\n"
-"PO-Revision-Date: 2018-05-20 14:02+0200\n"
+"POT-Creation-Date: 2018-05-21 21:51+0200\n"
+"PO-Revision-Date: 2018-05-21 21:51+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
@@ -55,60 +55,75 @@ msgstr ""
 msgid "Unexpected HTTP response status code {}"
 msgstr "Unerwarteter HTTP-Statuscode {}"
 
-#: main.py:480
+#: main.py:484
 msgid "Display word and its article"
 msgstr "Wort und sein Artikel anzeigen"
 
-#: main.py:482
+#: main.py:486
 msgid "Display the word itself"
 msgstr "Das Wort selbst anzeigen"
 
-#: main.py:484
+#: main.py:488
 msgid "Display word article"
 msgstr "Artikel anzeigen"
 
-#: main.py:486
+#: main.py:490
 msgid "Display word's part of speech"
 msgstr "Wortart anzeigen"
 
-#: main.py:488
+#: main.py:492
 msgid "Display commonness of the word, on scale 1 to 5"
 msgstr "Häufigkeit des Worts, auf einer Skala von 1 bis 5, anzeigen"
 
-#: main.py:491
+#: main.py:495
 msgid "Display the context in which the word is used"
 msgstr "Den Zusammenhang, in dem das Wort benutzt wird, anzeigen"
 
-#: main.py:494
+#: main.py:498
 msgid "Display proper word separation, each part on a separate line."
 msgstr "Richtige Worttrennung, jeden Teil in einer eigenen Zeile, anzeigen."
 
-#: main.py:497
+#: main.py:501
 msgid "Display word meaning overview"
 msgstr "Bedeutungsübersicht anzeigen"
 
-#: main.py:499
+#: main.py:503
 msgid "List word synonyms, each on a separate line"
 msgstr "Synonyme, jedes in einer eigenen Zeile, auflisten"
 
-#: main.py:501
+#: main.py:505
 msgid "Display word origin"
 msgstr "Wortherkunft anzeigen"
 
-#: main.py:503
+#: main.py:507
 msgid "List common word compounds"
 msgstr "Typische Verbindungen auflisten"
 
-#: main.py:505
+#: main.py:509
 msgid "List grammar forms"
 msgstr "Grammatik anzeigen"
 
-#: main.py:606
+#: main.py:512
+msgid ""
+"Display n-th result in case of multple words matching the input. Starts at 1."
+msgstr ""
+
+#: main.py:515
+msgid "Enable fuzzy word matching."
+msgstr ""
+
+#: main.py:612
 msgid "Word '{}' not found"
 msgstr "Wort '{}' nicht gefunden"
 
-msgid "Found {} matching words. Use the -r/--result argument to specify which one to display."
-msgstr "{} passende Wörter genfunden. Benutze die Option -r/--result um das korrekte Ergebnis anzuzeigen."
+#: main.py:617
+msgid ""
+"Found {} matching words. Use the -r/--result argument to specify which one "
+"to display."
+msgstr ""
+"{} passende Wörter genfunden. Benutze die Option -r/--result um das korrekte "
+"Ergebnis anzuzeigen."
 
+#: main.py:629
 msgid "No result with number {}."
 msgstr "Kein Ergebnis Nummer {}."

--- a/duden/locale/duden.pot
+++ b/duden/locale/duden.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-20 14:00+0200\n"
+"POT-Creation-Date: 2018-05-21 21:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,60 +51,71 @@ msgstr ""
 msgid "Unexpected HTTP response status code {}"
 msgstr ""
 
-#: main.py:480
+#: main.py:484
 msgid "Display word and its article"
 msgstr ""
 
-#: main.py:482
+#: main.py:486
 msgid "Display the word itself"
 msgstr ""
 
-#: main.py:484
+#: main.py:488
 msgid "Display word article"
 msgstr ""
 
-#: main.py:486
+#: main.py:490
 msgid "Display word's part of speech"
 msgstr ""
 
-#: main.py:488
+#: main.py:492
 msgid "Display commonness of the word, on scale 1 to 5"
 msgstr ""
 
-#: main.py:491
+#: main.py:495
 msgid "Display the context in which the word is used"
 msgstr ""
 
-#: main.py:494
+#: main.py:498
 msgid "Display proper word separation, each part on a separate line."
 msgstr ""
 
-#: main.py:497
+#: main.py:501
 msgid "Display word meaning overview"
 msgstr ""
 
-#: main.py:499
+#: main.py:503
 msgid "List word synonyms, each on a separate line"
 msgstr ""
 
-#: main.py:501
+#: main.py:505
 msgid "Display word origin"
 msgstr ""
 
-#: main.py:503
+#: main.py:507
 msgid "List common word compounds"
 msgstr ""
 
-#: main.py:505
+#: main.py:509
 msgid "List grammar forms"
 msgstr ""
 
-#: main.py:606
+#: main.py:512
+msgid "Display n-th result in case of multple words matching the input. Starts at 1."
+msgstr ""
+
+#: main.py:515
+msgid "Enable fuzzy word matching."
+msgstr ""
+
+#: main.py:612
 msgid "Word '{}' not found"
 msgstr ""
 
+#: main.py:617
 msgid "Found {} matching words. Use the -r/--result argument to specify which one to display."
 msgstr ""
 
+#: main.py:629
 msgid "No result with number {}."
 msgstr ""
+

--- a/duden/locale/es_ES.po
+++ b/duden/locale/es_ES.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2018-05-21 21:53+0200\n"
-"PO-Revision-Date: 2018-05-21 21:53+0200\n"
+"PO-Revision-Date: 2018-05-22 09:05+0200\n"
 "Last-Translator: Jorge Maldonado Ventura <jorgesumle@freakspot.net>\n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -55,7 +55,7 @@ msgstr "Código de estado de respuesta HTTP inesperado {}"
 
 #: main.py:484
 msgid "Display word and its article"
-msgstr "Mostrar palabra y su artículo"
+msgstr "Muestra palabra y su artículo"
 
 #: main.py:486
 msgid "Display the word itself"
@@ -106,10 +106,12 @@ msgstr "Lista formas gramaticales"
 msgid ""
 "Display n-th result in case of multple words matching the input. Starts at 1."
 msgstr ""
+"Muestra el resultado número n en caso de que varias palabras coincidan con "
+"la entrada. Empieza por 1."
 
 #: main.py:515
 msgid "Enable fuzzy word matching."
-msgstr ""
+msgstr "Habilita coincidencia de palabra parcial."
 
 #: main.py:612
 msgid "Word '{}' not found"
@@ -120,7 +122,9 @@ msgid ""
 "Found {} matching words. Use the -r/--result argument to specify which one "
 "to display."
 msgstr ""
+"Encontradas {} palabras coincidentes. Usa el argumento -r/--result para "
+"especificar cuál mostrar."
 
 #: main.py:629
 msgid "No result with number {}."
-msgstr ""
+msgstr "Ningún resultado con número {}."

--- a/duden/locale/es_ES.po
+++ b/duden/locale/es_ES.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-05-20 14:00+0200\n"
-"PO-Revision-Date: 2018-05-20 14:00+0200\n"
+"POT-Creation-Date: 2018-05-21 21:53+0200\n"
+"PO-Revision-Date: 2018-05-21 21:53+0200\n"
 "Last-Translator: Jorge Maldonado Ventura <jorgesumle@freakspot.net>\n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -53,54 +53,74 @@ msgstr "No se pudo establecer la conexión. Comprueba tu conexión a Internet."
 msgid "Unexpected HTTP response status code {}"
 msgstr "Código de estado de respuesta HTTP inesperado {}"
 
-#: main.py:480
+#: main.py:484
 msgid "Display word and its article"
 msgstr "Mostrar palabra y su artículo"
 
-#: main.py:482
+#: main.py:486
 msgid "Display the word itself"
 msgstr "Muestra la propia palabra"
 
-#: main.py:484
+#: main.py:488
 msgid "Display word article"
 msgstr "Muestra el artículo de palabra"
 
-#: main.py:486
+#: main.py:490
 msgid "Display word's part of speech"
 msgstr "Muestra la parte del habla de la palabra"
 
-#: main.py:488
+#: main.py:492
 msgid "Display commonness of the word, on scale 1 to 5"
 msgstr "Muestra la frecuencia de la palabra, del 1 al 5"
 
-#: main.py:491
+#: main.py:495
 msgid "Display the context in which the word is used"
 msgstr "Muestra el contexto en que se usa la palabra"
 
-#: main.py:494
+#: main.py:498
 msgid "Display proper word separation, each part on a separate line."
-msgstr "Muestra la adecuada separación de palabra, cada parte en una línea separada."
+msgstr ""
+"Muestra la adecuada separación de palabra, cada parte en una línea separada."
 
-#: main.py:497
+#: main.py:501
 msgid "Display word meaning overview"
 msgstr "Muestra el resumen del significado de la palabra"
 
-#: main.py:499
+#: main.py:503
 msgid "List word synonyms, each on a separate line"
 msgstr "Lista sinónimos de palabra, cada uno en una línea separada"
 
-#: main.py:501
+#: main.py:505
 msgid "Display word origin"
 msgstr "Muestra origen de palabra"
 
-#: main.py:503
+#: main.py:507
 msgid "List common word compounds"
 msgstr "Lista palabras compuestas comunes"
 
-#: main.py:505
+#: main.py:509
 msgid "List grammar forms"
 msgstr "Lista formas gramaticales"
 
-#: main.py:606
+#: main.py:512
+msgid ""
+"Display n-th result in case of multple words matching the input. Starts at 1."
+msgstr ""
+
+#: main.py:515
+msgid "Enable fuzzy word matching."
+msgstr ""
+
+#: main.py:612
 msgid "Word '{}' not found"
 msgstr "Palabra «{}» no encontrada"
+
+#: main.py:617
+msgid ""
+"Found {} matching words. Use the -r/--result argument to specify which one "
+"to display."
+msgstr ""
+
+#: main.py:629
+msgid "No result with number {}."
+msgstr ""


### PR DESCRIPTION
With that executor you don't need to install duden with pip if you don't want

It also solves a small issue with the `main.py` file importing a non-existing
module. That module only exists when duden is installed system-wide with pip. I
used a relative import because I think it's a better approach.