### PR TITLE
Add executor to the top level directory

### DIFF
--- a/duden/main.py
+++ b/duden/main.py
@@ -24,8 +24,8 @@ from itertools import cycle
 import bs4
 import requests
 
-from duden.common import (recursively_extract, print_tree_of_strings,
-                          clear_text, print_string_or_list)
+from .common import (recursively_extract, print_tree_of_strings,
+                     clear_text, print_string_or_list)
 
 
 URL_FORM = 'http://www.duden.de/rechtschreibung/{word}'

--- a/run_duden.py
+++ b/run_duden.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+from duden.main import main
+main()


### PR DESCRIPTION
With that executor you don't need to install duden with pip if you don't want

It also solves a small issue with the main.py file importing a non-existing
module. That module only exists when duden is installed system-wide with pip. I
used a relative import because I think it's a better approach.