### PR TITLE
Enable exporting word data in yaml format

### DIFF
--- a/completions/duden
+++ b/completions/duden
@@ -21,6 +21,7 @@ _duden () {
         --fuzzy
         --version
         --no-cache
+        --export
     )
     opts_with_arg=(
         -r --result

--- a/completions/duden.fish
+++ b/completions/duden.fish
@@ -1,1 +1,1 @@
-complete -c duden -xa "-h --help --title --name --article --part-of-speech --frequency --usage --word-separation --meaning-overview --synonyms --origin --compounds -g --grammar -r --result --fuzzy --version --no-cache"
+complete -c duden -xa "-h --help --title --name --article --part-of-speech --frequency --usage --word-separation --meaning-overview --synonyms --origin --compounds -g --grammar -r --result --fuzzy --version --no-cache --export"


### PR DESCRIPTION
This is useful both for generating test data and for storing important
parsed word data efficiently (as opposed to cached which stores the HTML
response).

Fixes #86