### PR TITLE
Add missing dependency on pyyaml

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ name = "pypi"
 requests = "*"
 crayons = "*"
 pyxdg = "*"
+pyyaml = "*"
 
 [dev-packages]
 "autopep8" = "*"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Python modules:
 * requests
 * crayons
 * pyxdg
+* pyyaml
 
 ## Testing
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         "requests",
         "beautifulsoup4",
         "crayons",
-        "pyxdg"
+        "pyxdg",
+        "pyyaml"
     ],
     keywords=['duden', 'duden.de', 'dictionary', 'cli', 'word'],
     license='MIT',


### PR DESCRIPTION
`duden`requires `pyyaml` but does not declare it as a dependency.

```
$ pip3 install duden
Collecting duden
  Downloading duden-0.13.0-py3-none-any.whl (23 kB)
Collecting requests
  Downloading requests-2.24.0-py2.py3-none-any.whl (61 kB)
     |████████████████████████████████| 61 kB 1.0 MB/s 
Collecting crayons
  Downloading crayons-0.3.1-py2.py3-none-any.whl (4.6 kB)
Collecting beautifulsoup4
  Downloading beautifulsoup4-4.9.1-py3-none-any.whl (115 kB)
     |████████████████████████████████| 115 kB 8.6 MB/s 
Collecting pyxdg
  Downloading pyxdg-0.26-py2.py3-none-any.whl (40 kB)
     |████████████████████████████████| 40 kB 10.5 MB/s 
Collecting chardet<4,>=3.0.2
  Using cached chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Collecting idna<3,>=2.5
  Downloading idna-2.10-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 14.3 MB/s 
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
  Downloading urllib3-1.25.10-py2.py3-none-any.whl (127 kB)
     |████████████████████████████████| 127 kB 19.8 MB/s 
Collecting certifi>=2017.4.17
  Downloading certifi-2020.6.20-py2.py3-none-any.whl (156 kB)
     |████████████████████████████████| 156 kB 13.5 MB/s 
Collecting colorama
  Using cached colorama-0.4.3-py2.py3-none-any.whl (15 kB)
Collecting soupsieve>1.2
  Downloading soupsieve-2.0.1-py3-none-any.whl (32 kB)
Installing collected packages: chardet, idna, urllib3, certifi, requests, colorama, crayons, soupsieve, beautifulsoup4, pyxdg, duden
Successfully installed beautifulsoup4-4.9.1 certifi-2020.6.20 chardet-3.0.4 colorama-0.4.3 crayons-0.3.1 duden-0.13.0 idna-2.10 pyxdg-0.26 requests-2.24.0 soupsieve-2.0.1 urllib3-1.25.10

$ duden Bahnhof
Traceback (most recent call last):
  File "/usr/local/bin/duden", line 5, in <module>
    from duden.cli import main
  File "/usr/local/lib/python3.8/site-packages/duden/cli.py", line 10, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'

$ pip3 install pyyaml
Collecting pyyaml
  Downloading PyYAML-5.3.1.tar.gz (269 kB)
     |████████████████████████████████| 269 kB 2.2 MB/s 
Building wheels for collected packages: pyyaml
  Building wheel for pyyaml (setup.py) ... done
  Created wheel for pyyaml: filename=PyYAML-5.3.1-cp38-cp38-macosx_10_14_x86_64.whl size=155752 sha256=1b3024c6b6421400728d4257513626a48e2814e322dc2a2b447b296dfe43039b
  Stored in directory: /Users/mnaberez/Library/Caches/pip/wheels/13/90/db/290ab3a34f2ef0b5a0f89235dc2d40fea83e77de84ed2dc05c
Successfully built pyyaml
Installing collected packages: pyyaml
Successfully installed pyyaml-5.3.1

$ duden Bahnhof
Bahnhof, der
============
Word type: Substantiv, maskulin
Commonness: 3/5
Separation: Bahn|hof
...
```