### PR TITLE
Handle words without grammar information

### DIFF
--- a/duden/word.py
+++ b/duden/word.py
@@ -272,7 +272,7 @@ class DudenWord():
         """
         section = self.soup.find('div', id='grammatik')
         if not section:
-            return None
+            return []
 
         table_nodes = self.soup.find_all('div', class_='wrap-table') \
             + self.soup.find_all('table', class_='mere-table')

--- a/tests/test_data/Qat.yaml
+++ b/tests/test_data/Qat.yaml
@@ -10,7 +10,7 @@ word_separation:
 meaning_overview: null
 origin: null
 compounds: null
-grammar_raw: null
+grammar_raw: []
 synonyms: null
 words_before:
 - q, Q

--- a/tests/test_data/einfach.yaml
+++ b/tests/test_data/einfach.yaml
@@ -43,7 +43,7 @@ compounds:
   - passen
   - stimmen
   - werden
-grammar_raw: null
+grammar_raw: []
 synonyms:
 - einmal, nicht doppelt, nicht mehrfachbequem
 words_before:

--- a/tests/test_online_attributes.py
+++ b/tests/test_online_attributes.py
@@ -93,3 +93,8 @@ def test_word_grammar(parsed_word, expected_dict):
                             for tags, string in expected_grammar]
 
     assert parsed_word.grammar_raw == expected_grammar
+
+def test_empty_grammar():
+    word = get("Wahlbeobachter")
+    assert word.grammar_raw == []
+    assert word.grammar() == []


### PR DESCRIPTION
Before this commit, grammar_raw returned None if no `#grammatik` element is found. This leads to TypeError in `Word.grammar` and seems unintuitive, since in other cases an empty list is retuned (see GH-21).
Now grammar_raw returns an empty list if no grammar section is found.