### PR TITLE
Added pronunciation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,4 @@ update-test-data:
 	./run_duden.py --export Kragen > tests/test_data/Kragen.yaml
 	./run_duden.py --export Petersilie > tests/test_data/Petersilie.yaml
 	./run_duden.py --export einfach -r1 > tests/test_data/einfach.yaml
+	./run_duden.py --export Keyboard > tests/test_data/Keyboard.yaml

--- a/completions/duden
+++ b/completions/duden
@@ -22,6 +22,7 @@ _duden () {
         --version
         --no-cache
         --export
+        --phonetic
     )
     opts_with_arg=(
         -r --result

--- a/completions/duden.fish
+++ b/completions/duden.fish
@@ -1,1 +1,1 @@
-complete -c duden -xa "-h --help --title --name --article --part-of-speech --frequency --usage --word-separation --meaning-overview --synonyms --origin --compounds -g --grammar -r --result --fuzzy --version --no-cache --export"
+complete -c duden -xa "-h --help --title --name --article --part-of-speech --frequency --usage --word-separation --meaning-overview --synonyms --origin --compounds -g --grammar -r --result --fuzzy --version --no-cache --export --phonetic"

--- a/duden/__version__.py
+++ b/duden/__version__.py
@@ -2,4 +2,4 @@
 """
 Contains module version constant
 """
-__version__ = '0.14.3'
+__version__ = '0.14.4'

--- a/duden/cli.py
+++ b/duden/cli.py
@@ -52,6 +52,9 @@ def display_word(word, args):
     elif args.compounds:
         if word.compounds:
             display_compounds(word, args.compounds)
+    elif args.phonetic:
+        if word.phonetic:
+            print(word.phonetic)
     elif args.grammar:
         display_grammar(word, args.grammar)
     elif args.export:
@@ -114,6 +117,8 @@ def parse_args():
 
     parser.add_argument('-V', '--version', action='store_true',
                         help=_('print program version'))
+    parser.add_argument('--phonetic', action='store_true',
+                        help=('displays pronunciation'))
 
     return parser.parse_args()
 

--- a/duden/cli.py
+++ b/duden/cli.py
@@ -118,7 +118,7 @@ def parse_args():
     parser.add_argument('-V', '--version', action='store_true',
                         help=_('print program version'))
     parser.add_argument('--phonetic', action='store_true',
-                        help=('displays pronunciation'))
+                        help=_('display pronunciation'))
 
     return parser.parse_args()
 

--- a/duden/display.py
+++ b/duden/display.py
@@ -123,7 +123,7 @@ def describe_word(word):
     print(yellow('=' * len(word.title)))
 
     if word.phonetic:
-         print(white(_('Pronunciation:'), bold=True), word.phonetic)
+        print(white(_('Pronunciation:'), bold=True), word.phonetic)
     if word.part_of_speech:
         print(white(_('Word type:'), bold=True), word.part_of_speech)
     if word.usage:

--- a/duden/display.py
+++ b/duden/display.py
@@ -122,6 +122,8 @@ def describe_word(word):
     print(yellow(word.title, bold=True))
     print(yellow('=' * len(word.title)))
 
+    if word.phonetic:
+         print(white(_('Pronunciation:'), bold=True), word.phonetic)
     if word.part_of_speech:
         print(white(_('Word type:'), bold=True), word.part_of_speech)
     if word.usage:

--- a/duden/word.py
+++ b/duden/word.py
@@ -348,7 +348,8 @@ class DudenWord():
     @property
     def phonetic(self):
         """
-        Returns pronunciation of the word in phonetic notation (https://en.wikipedia.org/wiki/International_Phonetic_Alphabet)
+        Returns pronunciation of the word in phonetic notation.
+        See: https://en.wikipedia.org/wiki/International_Phonetic_Alphabet
         """
         ipa = self.soup.find('span', {"class": "ipa"})
         if ipa is not None:

--- a/duden/word.py
+++ b/duden/word.py
@@ -344,3 +344,14 @@ class DudenWord():
     def words_after(self):
         """Returns 5 words after this one in duden database"""
         return [name for name, _ in self.before_after_structure['Im Alphabet danach']]
+
+    @property
+    def phonetic(self):
+        """
+        Returns pronunciation of the word in phonetic notation (https://en.wikipedia.org/wiki/International_Phonetic_Alphabet)
+        """
+        ipa = self.soup.find('span', {"class": "ipa"})
+        if ipa is not None:
+            return ipa.get_text()
+
+        return None

--- a/duden/word.py
+++ b/duden/word.py
@@ -14,7 +14,7 @@ from .common import recursively_extract, table_node_to_tagged_cells, clear_text
 EXPORT_ATTRIBUTES = [
     'name', 'urlname', 'title', 'article', 'part_of_speech', 'usage',
     'frequency', 'word_separation', 'meaning_overview', 'origin', 'compounds',
-    'grammar_raw', 'synonyms', 'words_before', 'words_after'
+    'grammar_raw', 'synonyms', 'words_before', 'words_after', 'phonetic'
 ]
 
 gettext.install('duden', os.path.join(os.path.dirname(__file__), 'locale'))

--- a/tests/test_data/Barmherzigkeit.yaml
+++ b/tests/test_data/Barmherzigkeit.yaml
@@ -41,3 +41,4 @@ words_after:
 - Barmixerin
 - Bar-Mizwa
 - Bar-Mizwa
+phonetic: null

--- a/tests/test_data/Feiertag.yaml
+++ b/tests/test_data/Feiertag.yaml
@@ -80,3 +80,4 @@ words_after:
 - Feiertagsarbeit
 - Feiertagsruhe
 - Feiertagsstille
+phonetic: null

--- a/tests/test_data/Keyboard.yaml
+++ b/tests/test_data/Keyboard.yaml
@@ -1,0 +1,56 @@
+name: Keyboard
+urlname: Keyboard
+title: Keyboard, das
+article: das
+part_of_speech: Substantiv, Neutrum
+usage: null
+frequency: 2
+word_separation:
+- Key
+- board
+meaning_overview:
+- elektronisch verstärktes Tasteninstrument
+- '[Geräteteil mit der] Tastatur (b) eines Personal Computers'
+origin: 'englisch keyboard, eigentlich = Klaviatur, Tastatur, aus: key = Taste (eigentlich =
+  Schlüssel, wohl in der Bedeutung beeinflusst von mittellateinisch clavis, Klavier)
+  und board = Brett'
+compounds: null
+grammar_raw:
+- - - Nominativ
+    - Singular
+  - das Keyboard
+- - - Nominativ
+    - Plural
+  - die Keyboards
+- - - Genitiv
+    - Singular
+  - des Keyboards
+- - - Genitiv
+    - Plural
+  - der Keyboards
+- - - Dativ
+    - Singular
+  - dem Keyboard
+- - - Dativ
+    - Plural
+  - den Keyboards
+- - - Akkusativ
+    - Singular
+  - das Keyboard
+- - - Akkusativ
+    - Plural
+  - die Keyboards
+synonyms: null
+words_before:
+- Key-Accounter
+- Key-Accounterin
+- Key-Account-Management
+- Key-Account-Manager
+- Key-Account-Managerin
+words_after:
+- Keyboarder
+- Keyboarderin
+- Keyboardspieler
+- Keyboardspielerin
+- Keylogger
+phonetic: '[ˈkiːbɔːɐ̯t]'

--- a/tests/test_data/Kragen.yaml
+++ b/tests/test_data/Kragen.yaml
@@ -33,3 +33,4 @@ words_after:
 - Kragenknopf
 - kragenlos
 - Kragennummer
+phonetic: null

--- a/tests/test_data/Petersilie.yaml
+++ b/tests/test_data/Petersilie.yaml
@@ -55,3 +55,4 @@ words_after:
 - Petersiliensoße
 - Petersilienwurzel
 - Peterskirche
+phonetic: '[petɐˈziːli̯ə]'

--- a/tests/test_data/Qat.yaml
+++ b/tests/test_data/Qat.yaml
@@ -24,3 +24,4 @@ words_after:
 - qcm
 - qdm
 - q. e. d.
+phonetic: '[kat]'

--- a/tests/test_data/einfach.yaml
+++ b/tests/test_data/einfach.yaml
@@ -58,3 +58,4 @@ words_after:
 - Einfaches
 - einfachgesetzlich
 - Einfachheit
+phonetic: '[ˈaɪ̯nfax]'

--- a/tests/test_data/laufen.yaml
+++ b/tests/test_data/laufen.yaml
@@ -232,3 +232,4 @@ words_after:
 - Laufer
 - Läufer
 - Lauferei
+phonetic: null

--- a/tests/test_online_attributes.py
+++ b/tests/test_online_attributes.py
@@ -47,7 +47,7 @@ word_data = generate_word_data()
 
 basic_attributes = [
     'title', 'name', 'article', 'part_of_speech', 'frequency', 'usage',
-    'word_separation', 'synonyms', 'origin', 'words_before', 'words_after'
+    'word_separation', 'synonyms', 'origin', 'words_before', 'words_after', 'phonetic'
 ]
 
 word_param = pytest.mark.parametrize("parsed_word,expected_dict", word_data)


### PR DESCRIPTION
Certain words have a pronunciation attribute, e.g. [keyboard](https://www.duden.de/rechtschreibung/Keyboard), where you can find the pronunciation in [IPA notation](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet).

HTML looks like this:
```html
<span class="ipa">[ˈkiːbɔːɐ̯t]</span>
```

Example:
```
$ python3 run_duden.py Keyboard
Keyboard, das
=============
Pronunciation: [ˈkiːbɔːɐ̯t]
Word type: Substantiv, Neutrum
Commonness: 2/5
Separation: Key|board
Meaning overview:
 0. elektronisch verstärktes Tasteninstrument

 1. [Geräteteil mit der] Tastatur (b) eines Personal Computers```