### PR TITLE
replaced http with https urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Duden [![Build Status](https://travis-ci.org/radomirbosak/duden.svg?branch=master)](https://travis-ci.org/radomirbosak/duden) [![Version](http://img.shields.io/pypi/v/duden.svg?style=flat)](https://pypi.python.org/pypi/duden/)
 
-**duden** is a CLI-based program and python module, which can provide various information about given german word. The provided data are parsed from german dictionary [duden.de](http://duden.de).
+**duden** is a CLI-based program and python module, which can provide various information about given german word. The provided data are parsed from german dictionary [duden.de](https://duden.de).
 
 ![duden screenshot](screenshot.png)
 

--- a/duden/__init__.py
+++ b/duden/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-The duden package can parse the http://www.duden.de/ word information.
+The duden package can parse the https://www.duden.de/ word information.
 
 The `get` function is used to return parsed word, when provided with the word's
 exact url name. The `search` function is used to search for words, either

--- a/duden/search.py
+++ b/duden/search.py
@@ -15,8 +15,8 @@ from .word import DudenWord
 from .common import clear_text
 
 
-URL_FORM = 'http://www.duden.de/rechtschreibung/{word}'
-SEARCH_URL_FORM = 'http://www.duden.de/suchen/dudenonline/{word}'
+URL_FORM = 'https://www.duden.de/rechtschreibung/{word}'
+SEARCH_URL_FORM = 'https://www.duden.de/suchen/dudenonline/{word}'
 
 
 def sanitize_word(word):
@@ -102,7 +102,7 @@ def get_word_of_the_day():
     """
     Scrapes the word of the day and returns DudenWord instance of it.
     """
-    html_content = requests.get("http://www.duden.de").content
+    html_content = requests.get("https://www.duden.de").content
     soup = bs4.BeautifulSoup(html_content, "html.parser")
     link = soup.find("a", class_="scene__title-link").get("href")
     word = link.split("/")[-1]  # get word from "/rechtschreibung/word"

--- a/duden/word.py
+++ b/duden/word.py
@@ -26,7 +26,7 @@ class DudenWord():
 
     Example:
 
-        > r = requests.get('http://www.duden.de/rechtschreibung/Hase')
+        > r = requests.get('https://www.duden.de/rechtschreibung/Hase')
         > soup = bs4.BeautifulSoup(r.text)
         > word = duden.DudenWord(soup)
         > word


### PR DESCRIPTION
Hi @radomirbosak 

I noticed that `duden` uses **`http`** instead of **`https`** urls for requesting data from `duden.de`.

To improve privacy I suggest using `https` urls.

Regards,
Henning