### PR TITLE
Display word origin in CLI word overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 New features:
 * Add 10 second timeout to every network request to prevent program hanging #164
 * Display word origin in the standard CLI word output #168
+* Add new word attribute `DudenWord.grammar_overview` or `--grammar-overview` #168
+
+```console
+$ duden Barmherzigkeit --grammar-overview
+die Barmherzigkeit; Genitiv: der Barmherzigkeit
+```
 
 Intenal:
 * Change dependency management tool from pipenv to poetry #160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 New features:
 * Add 10 second timeout to every network request to prevent program hanging #164
+* Display word origin in the standard CLI word output #168
 
 Intenal:
 * Change dependency management tool from pipenv to poetry #160
 
 Documentation:
 * Document localization process #167
+* Document word origin property #168
 
 ## 0.17.0 (2022-09-16)
 

--- a/completions/duden
+++ b/completions/duden
@@ -15,6 +15,7 @@ _duden () {
         --meaning-overview
         --synonyms
         --origin
+        --grammar-overview
         --compounds
         -g --grammar
         -r --result

--- a/completions/duden.fish
+++ b/completions/duden.fish
@@ -1,1 +1,1 @@
-complete -c duden -xa "-h --help --title --name --article --part-of-speech --frequency --usage --word-separation --meaning-overview --synonyms --origin --compounds -g --grammar -r --result --fuzzy --version --no-cache --export --phonetic --alternative-spellings"
+complete -c duden -xa "-h --help --title --name --article --part-of-speech --frequency --usage --word-separation --meaning-overview --synonyms --origin --grammar-overview --compounds -g --grammar -r --result --fuzzy --version --no-cache --export --phonetic --alternative-spellings"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,9 @@ This example showcases the most useful functions of the `DudenWord` class.
 > w.origin
 'mittelhochdeutsch barmherzekeit, barmherze, althochdeutsch armherzi, nach (kirchen)lateinisch misericordia'
 
+> w.grammar_overview
+'die Barmherzigkeit; Genitiv: der Barmherzigkeit'
+
 > w = duden.get('laufen')
 > w.compounds
 {

--- a/duden/cli.py
+++ b/duden/cli.py
@@ -54,6 +54,9 @@ def display_word(word, args):
     elif args.origin:
         if word.origin:
             print(word.origin)
+    elif args.grammar_overview:
+        if word.grammar_overview:
+            print(word.grammar_overview)
     elif args.compounds:
         if word.compounds:
             display_compounds(word, args.compounds)
@@ -112,6 +115,11 @@ def parse_args():
         "--synonyms", action="store_true", help=_("list synonyms (line separated)")
     )
     parser.add_argument("--origin", action="store_true", help=_("display origin"))
+    parser.add_argument(
+        "--grammar-overview",
+        action="store_true",
+        help=_("display short grammar overview"),
+    )
     parser.add_argument(
         "--compounds", nargs="?", const="ALL", help=_("list common compounds")
     )

--- a/duden/display.py
+++ b/duden/display.py
@@ -155,6 +155,9 @@ def describe_word(word):
             )
         )
 
+    if word.origin:
+        print(white(_("Origin:"), bold=True), word.origin)
+
     if word.meaning_overview:
         print(white(_("Meaning overview:"), bold=True))
         print_tree_of_strings(word.meaning_overview)

--- a/duden/display.py
+++ b/duden/display.py
@@ -158,6 +158,9 @@ def describe_word(word):
     if word.origin:
         print(white(_("Origin:"), bold=True), word.origin)
 
+    if word.grammar_overview:
+        print(white(_("Grammar:"), bold=True), word.grammar_overview)
+
     if word.meaning_overview:
         print(white(_("Meaning overview:"), bold=True))
         print_tree_of_strings(word.meaning_overview)

--- a/duden/word.py
+++ b/duden/word.py
@@ -21,6 +21,7 @@ EXPORT_ATTRIBUTES = [
     "word_separation",
     "meaning_overview",
     "origin",
+    "grammar_overview",
     "compounds",
     "grammar_raw",
     "synonyms",
@@ -248,6 +249,22 @@ class DudenWord:
         if section.header:
             section.header.extract()
         return section.text.strip()
+
+    @property
+    def grammar_overview(self):
+        """
+        Return short grammar overview
+        """
+        section = self.soup.find("div", id="grammatik")
+        if section is None:
+            return None
+
+        section = copy.copy(section)
+        if section.header:
+            section.header.extract()
+        if section.nav:
+            section.nav.extract()
+        return section.text.strip() or None
 
     @property
     def compounds(self):

--- a/tests/test_data/Barmherzigkeit.yaml
+++ b/tests/test_data/Barmherzigkeit.yaml
@@ -13,6 +13,7 @@ word_separation:
 meaning_overview: barmherziges Wesen, Verhalten
 origin: mittelhochdeutsch barmherzekeit, barmherze, althochdeutsch armherzi, nach
   (kirchen)lateinisch misericordia
+grammar_overview: 'die Barmherzigkeit; Genitiv: der Barmherzigkeit'
 compounds: null
 grammar_raw: []
 synonyms:

--- a/tests/test_data/Feiertag.yaml
+++ b/tests/test_data/Feiertag.yaml
@@ -13,6 +13,7 @@ meaning_overview:
 - jährlich wiederkehrender Gedenktag [an dem nicht gearbeitet wird]
 - Tag, an dem jemand etwas besonders Schönes erlebt
 origin: mittelhochdeutsch vīretac, althochdeutsch fīratag
+grammar_overview: null
 compounds:
   adjektive:
   - allgemein

--- a/tests/test_data/Keyboard.yaml
+++ b/tests/test_data/Keyboard.yaml
@@ -14,6 +14,7 @@ meaning_overview:
 origin: 'englisch keyboard, eigentlich = Klaviatur, Tastatur, aus: key = Taste (eigentlich =
   Schlüssel, wohl in der Bedeutung beeinflusst von mittellateinisch clavis, Klavier)
   und board = Brett'
+grammar_overview: 'das Keyboard; Genitiv: des Keyboards, Plural: die Keyboards'
 compounds: null
 grammar_raw: []
 synonyms: null

--- a/tests/test_data/Kragen.yaml
+++ b/tests/test_data/Kragen.yaml
@@ -17,6 +17,8 @@ meaning_overview:
 - ''
 origin: mittelhochdeutsch krage = Hals, Kehle, Nacken; Kragen (1), ursprünglich =
   Schlund
+grammar_overview: 'der Kragen; Genitiv: des Kragens, Plural: die Kragen, süddeutsch,
+  österreichisch, schweizerisch: Krägen'
 compounds: null
 grammar_raw: []
 synonyms:

--- a/tests/test_data/Meme.yaml
+++ b/tests/test_data/Meme.yaml
@@ -11,6 +11,8 @@ meaning_overview: (interessantes oder witziges) Bild, Video o. Ä., das in sozi
   Netzwerken schnell und weit verbreitet wird
 origin: englisch meme, eigentlich = weit verbreitete Idee o. Ä., zu griechisch mnḗmē =
   Gedächtnis
+grammar_overview: 'das Meme; Genitiv: des Memes, Plural: die Memes oder das Mem; Genitiv:
+  des Mems, Plural: die Meme'
 compounds: null
 grammar_raw: []
 synonyms: null

--- a/tests/test_data/Petersilie.yaml
+++ b/tests/test_data/Petersilie.yaml
@@ -14,6 +14,7 @@ meaning_overview: zum Würzen und Garnieren von Speisen verwendete Pflanze mit d
   glatten oder krausen, mehrfach gefiederten Blättern und schlanker Pfahlwurzel
 origin: mittelhochdeutsch pētersil(je), althochdeutsch petersilie, petrasile < mittellateinisch
   petrosilium < lateinisch petroselinon < griechisch petrosélinon = Felsen-, Steineppich
+grammar_overview: 'die Petersilie; Genitiv: der Petersilie, Plural: die Petersilien'
 compounds: null
 grammar_raw: []
 synonyms:

--- a/tests/test_data/Qat.yaml
+++ b/tests/test_data/Qat.yaml
@@ -9,6 +9,7 @@ word_separation:
 - Qat
 meaning_overview: null
 origin: null
+grammar_overview: null
 compounds: null
 grammar_raw: []
 synonyms: null

--- a/tests/test_data/einfach.yaml
+++ b/tests/test_data/einfach.yaml
@@ -15,6 +15,7 @@ meaning_overview:
 - keinen großen Aufwand, Luxus treibend oder aufweisend; ohne große Ansprüche auftretend;
   schlicht, bescheiden
 origin: spätmittelhochdeutsch einfach, -fach
+grammar_overview: null
 compounds:
   adjektive:
   - billig

--- a/tests/test_data/laufen.yaml
+++ b/tests/test_data/laufen.yaml
@@ -43,6 +43,7 @@ meaning_overview:
 - sich günstig entwickeln
 origin: mittelhochdeutsch loufen, althochdeutsch (h)louf(f)an, wahrscheinlich ursprünglich
   = (im Kreise) hüpfen, tanzen
+grammar_overview: null
 compounds:
   adjektive:
   - dumm

--- a/tests/test_online_attributes.py
+++ b/tests/test_online_attributes.py
@@ -54,6 +54,7 @@ basic_attributes = [
     "word_separation",
     "synonyms",
     "origin",
+    "grammar_overview",
     "words_before",
     "words_after",
     "phonetic",


### PR DESCRIPTION
# `grammar_overview` attribute
New attribute `grammar_overview` was added
```console
$ duden Barmherzigkeit --grammar-overview
die Barmherzigkeit; Genitiv: der Barmherzigkeit
```

```python
> import duden
> w = duden.get("Barmherzigkeit")
> w.grammar_overview
'die Barmherzigkeit; Genitiv: der Barmherzigkeit'
```

# `origin` attribute
* Include in CLI word description