### PR TITLE
Fix usage document on synonyms

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,7 +36,7 @@ This example showcases the most useful functions of the `DudenWord` class.
 'barmherziges Wesen, Verhalten'
 
 > w.synonyms
-'[Engels]güte, Milde, Nachsicht, Nachsichtigkeit; (gehoben) Herzensgüte, Mildtätigkeit, Seelengüte; (bildungssprachlich) Humanität, Indulgenz; (veraltend) Wohltätigkeit; (Religion) Gnade'
+['[Engels]güte, Milde, Nachsicht, Nachsichtigkeit']
 
 > w.origin
 'mittelhochdeutsch barmherzekeit, barmherze, althochdeutsch armherzi, nach (kirchen)lateinisch misericordia'


### PR DESCRIPTION
Relates to #181

It looks like synonym sections of all words now have only a single `<li>` item, which causes `DudenWord.synonyms` to always return 1-item array. Usage document is updated accordingly.