### PR TITLE
Redirect users when trying to use the removed properties and CLI options

### DIFF
--- a/duden/cli.py
+++ b/duden/cli.py
@@ -125,6 +125,9 @@ def parse_args():
         "--compounds", nargs="?", const="ALL", help=_("list common compounds")
     )
     parser.add_argument(
+        "-g", "--grammar", const="_", nargs="?", help="Removed. Use -i/--inflect"
+    )
+    parser.add_argument(
         "-i", "--inflect", action="store_true", help=_("display inflections")
     )
     parser.add_argument(
@@ -169,8 +172,11 @@ def parse_args():
         action="store_true",
         help=_("display alternative spellings"),
     )
+    args = parser.parse_args()
 
-    return parser.parse_args()
+    if args.grammar:
+        parser.error("The -g/--grammar was replaced with -i/--inflect .")
+    return args
 
 
 def main():

--- a/duden/word.py
+++ b/duden/word.py
@@ -315,6 +315,16 @@ class DudenWord:
         return compounds_sorted
 
     @property
+    def grammar(self):
+        """Redirect users to new function"""
+        raise RuntimeError("The .grammar property was replaced by .inflection")
+
+    @property
+    def grammar_raw(self):
+        """Redirect users to new function"""
+        raise RuntimeError("The .grammar_raw property was replaced by .inflection")
+
+    @property
     def inflection(self):
         """
         Return word's Inflector object with methods for conjugation and declension


### PR DESCRIPTION
What was removed:
* -g/--grammar CLI option
* .grammar and .grammar_raw word property

Fixes: #194